### PR TITLE
Refactor hero layout and project cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,10 @@
         }
 
         .nav-container {
-            max-width: 1200px;
-            margin: 0 auto;
+            max-width: none;
+            width: 100%;
+            margin: 0;
+            padding: 0 1rem;
             display: flex;
             justify-content: space-between;
             align-items: center;
@@ -83,22 +85,50 @@
         /* Main content */
         main {
             margin-top: 80px;
-            padding: 2rem;
+            padding: 2rem 1rem;
         }
 
         .container {
-            max-width: 1200px;
-            margin: 0 auto;
+            max-width: none;
+            width: 100%;
+            margin: 0;
+            padding: 0 1rem;
         }
 
         /* Hero Section */
         .hero {
-            text-align: center;
-            padding: 4rem 0 6rem;
+            padding: 6rem 0 6rem;
         }
 
-        .hero h1 {
+        .hero-container {
+            display: flex;
+            align-items: center;
+            gap: 3rem;
+        }
+
+        .hero-left {
+            flex: 1;
+            min-height: 300px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .hero-name {
             font-size: 3rem;
+            font-weight: 300;
+            color: #2c2c2c;
+        }
+
+        .hero-right {
+            flex: 2;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+        }
+
+        .hero-right h2 {
+            font-size: 2.2rem;
             font-weight: 300;
             margin-bottom: 1rem;
             color: #2c2c2c;
@@ -109,8 +139,6 @@
             color: #666;
             margin-bottom: 2rem;
             max-width: 600px;
-            margin-left: auto;
-            margin-right: auto;
         }
 
         /* Sections */
@@ -134,11 +162,16 @@
             color: #2c2c2c;
         }
 
+        .about-title {
+            text-align: left;
+            margin-bottom: 1.5rem;
+        }
+
         /* About Section */
         .about-content {
             max-width: 800px;
-            margin: 0 auto;
-            text-align: center;
+            margin: 0;
+            text-align: left;
             font-size: 1.1rem;
             line-height: 1.8;
             color: #555;
@@ -147,12 +180,16 @@
         /* Projects Grid */
         .projects-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            grid-template-columns: repeat(4, 1fr);
             gap: 2rem;
             margin-bottom: 2rem;
         }
 
         .project-tile {
+            display: flex;
+            flex-direction: column;
+            min-height: 420px;
+            aspect-ratio: 3 / 4;
             background: white;
             border-radius: 12px;
             padding: 2rem;
@@ -337,13 +374,30 @@
         }
 
         /* Responsive */
-        @media (max-width: 768px) {
+        @media (max-width: 1024px) {
+            .projects-grid {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            .hero-container {
+                flex-direction: column;
+                text-align: center;
+            }
+            .hero-right {
+                align-items: center;
+            }
+        }
+
+        @media (max-width: 600px) {
             .nav-links {
                 gap: 1rem;
             }
 
-            .hero h1 {
+            .hero-name {
                 font-size: 2rem;
+                margin-bottom: 1rem;
+            }
+            .hero-right h2 {
+                font-size: 1.6rem;
             }
 
             .projects-grid {
@@ -378,79 +432,88 @@
 
     <main>
         <div class="container">
-            <section class="hero">
-                <h1>Data & AI Consultant</h1>
-                <p class="subtitle">Delivering scalable data automation and AI-powered solutions across fintech, insurance, and regulatory domains</p>
-            </section>
-
-            <section id="about" class="section">
-                <h2 class="section-title">About</h2>
-                <div class="about-content">
-                    <p>Data & AI Consultant with 4+ years of experience delivering data automation and AI-powered solutions in fintech, insurance, and regulatory domains. Skilled in building scalable cloud architectures, integrating LLMs, and leading cross-functional teams.</p>
+            <section class="hero" id="about">
+                <div class="hero-container">
+                    <div class="hero-left">
+                        <h1 class="hero-name">Preetham Shylendhra</h1>
+                    </div>
+                    <div class="hero-right">
+                        <h2>Data &amp; AI Consultant</h2>
+                        <p class="subtitle">Delivering scalable data automation and AI-powered solutions across fintech, insurance, and regulatory domains</p>
+                        <h2 class="section-title about-title">About</h2>
+                        <div class="about-content">
+                            <p>Data &amp; AI Consultant with 4+ years of experience delivering data automation and AI-powered solutions in fintech, insurance, and regulatory domains. Skilled in building scalable cloud architectures, integrating LLMs, and leading cross-functional teams.</p>
+                        </div>
+                    </div>
                 </div>
             </section>
 
             <section id="projects" class="section">
                 <h2 class="section-title">Projects</h2>
                 <div class="projects-grid">
-                    <div class="project-tile" data-project="gcp-workflows">
-                        <h3>Automated Data Workflows</h3>
-                        <p>GCP, Vertex AI and Python solutions for automated data processing and workflow management.</p>
+                    <div class="project-tile" data-project="pro-scraper">
+                        <h3>Pro Scraper</h3>
+                        <p>LLM-powered console tool converting insurer HTML to structured JSON, cutting extraction time by 90%.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="streamlit-platform">
-                        <h3>Data Configuration Platform</h3>
-                        <p>Drag-and-drop data configuration platform using Streamlit for Solidatus.</p>
+
+                    <div class="project-tile" data-project="semantic-mapper">
+                        <h3>Semantic Mapper</h3>
+                        <p>Local LLM solution aligning trade descriptions with a master list for fast, accurate mappings.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="llm-pipeline">
-                        <h3>LLM-Driven Code Generation</h3>
-                        <p>Pipeline converting complex business rules to code snippets using advanced language models.</p>
+
+                    <div class="project-tile" data-project="adaptive-browser-agent">
+                        <h3>Adaptive Browser Automation POC</h3>
+                        <p>Multimodal agent translating plain-English commands into actions for flexible portal automation.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="claude-reports">
-                        <h3>Claude-Based Report Generation</h3>
-                        <p>Automated connection reports for Legacy Systems using Claude AI technology.</p>
+
+                    <div class="project-tile" data-project="mentorship-leadership">
+                        <h3>Mentorship &amp; Solution Leadership</h3>
+                        <p>Guided teams through reusable workflows and documentation, enabling rapid onboarding and delivery.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="llm-scraper">
-                        <h3>Containerized LLM Scraper</h3>
-                        <p>High-performance data extraction solution achieving 90% faster processing times.</p>
+
+                    <div class="project-tile" data-project="rule-to-js">
+                        <h3>Rule-to-JavaScript Converter</h3>
+                        <p>Python and LLM engine generating validated JavaScript and tests from business rules in two days.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="trade-mapping">
-                        <h3>Trade-Term Mapping Solution</h3>
-                        <p>GPT API-powered automation reducing task completion time by 90%.</p>
+
+                    <div class="project-tile" data-project="insurer-automation">
+                        <h3>Insurer Site Automation</h3>
+                        <p>Selenium-driven flows mapping question sets to product parameters with reliable validation logic.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="browser-automation">
-                        <h3>Multimodal AI Browser Automation</h3>
-                        <p>Intelligent browser automation for insurer portal interaction and data processing.</p>
+
+                    <div class="project-tile" data-project="fraxses-layer">
+                        <h3>Unified Data Access Layer</h3>
+                        <p>Federated models in Fraxses giving governed, virtual access to distributed datasets.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="langchain-parsing">
-                        <h3>LangChain Data Quality Extraction</h3>
-                        <p>Advanced parsing solution for unstructured data quality assessment and extraction.</p>
+
+                    <div class="project-tile" data-project="solidatus-ingestion">
+                        <h3>Automated Data Integration</h3>
+                        <p>Configurable connectors standardising file ingestion into Solidatus, reclaiming 200+ hours monthly.</p>
                     </div>
-                    
+
+                    <div class="project-tile" data-project="predictive-maintenance">
+                        <h3>Predictive Maintenance</h3>
+                        <p>WPS Analytics models forecasting turbine failures 24 hours early to speed root cause analysis.</p>
+                    </div>
+
+                    <div class="project-tile" data-project="regulatory-compliance">
+                        <h3>Regulatory Compliance Models</h3>
+                        <p>Developed 250+ data lineage models for transparent, reliable reporting at BNYM.</p>
+                    </div>
+
+                    <div class="project-tile" data-project="markets-architecture">
+                        <h3>Global Markets Architecture</h3>
+                        <p>Automated diagrams of 400+ systems with scheduled updates for informed decision making.</p>
+                    </div>
+
                     <div class="project-tile" data-project="axiom-connector">
-                        <h3>Axiom Connector</h3>
-                        <p>Engineered solution reducing reporting cycles by 50% through optimized data connections.</p>
+                        <h3>Custom Connector</h3>
+                        <p>Reusable pipeline integrating Axiom with regulatory tools, halving reporting cycles.</p>
                     </div>
-                    
-                    <div class="project-tile" data-project="ml-turbine">
-                        <h3>Turbine Failure Detection</h3>
-                        <p>Machine Learning solution for predictive maintenance, detecting failures 24 hours early.</p>
-                    </div>
-                    
-                    <div class="project-tile" data-project="regulatory-reporting">
-                        <h3>Regulatory Reporting Acceleration</h3>
-                        <p>Built 1000+ lineage models for large banks to streamline regulatory compliance.</p>
-                    </div>
-                    
-                    <div class="project-tile" data-project="powerbi-nlp">
-                        <h3>Power BI NLP Dashboards</h3>
-                        <p>Advanced analytics dashboards reducing survey analysis effort by 50%.</p>
+
+                    <div class="project-tile" data-project="regulatory-design">
+                        <h3>Regulatory Design Dashboards</h3>
+                        <p>Power BI and NLP analysis revealing sentiment trends and reducing survey effort by 50%.</p>
                     </div>
                 </div>
             </section>
@@ -530,213 +593,139 @@
 
     <script>
         // Project details data
+
         const projectDetails = {
-            'gcp-workflows': {
-                title: 'Automated Data Workflows with GCP, Vertex AI and Python',
+            'pro-scraper': {
+                title: 'Pro Scraper – Data Extraction from Insurer Sites',
                 content: `
-                    <p>Developed comprehensive automated data workflows leveraging Google Cloud Platform's robust infrastructure and Vertex AI's machine learning capabilities.</p>
-                    
-                    <h4>Key Achievements:</h4>
                     <ul>
-                        <li>Mentored teams in hands-on solution design, accelerating prototyping phases</li>
-                        <li>Implemented scalable data processing pipelines using GCP services</li>
-                        <li>Integrated Vertex AI for intelligent data processing and analysis</li>
-                        <li>Reduced manual intervention by 80% through intelligent automation</li>
+                        <li>Manual JavaScript scraping took about two weeks per insurer and broke with every UI change.</li>
+                        <li>Built a drop-in console tool that feeds raw HTML to a local LLM and outputs structured JSON instantly.</li>
+                        <li>Standardised usage with docs and mentoring, cutting extraction time to two days and keeping data local.</li>
                     </ul>
-                    
-                    <h4>Technologies Used:</h4>
-                    <p>Google Cloud Platform, Vertex AI, Python, Cloud Functions, BigQuery, Cloud Storage</p>
                 `
             },
-            'streamlit-platform': {
-                title: 'Drag-and-Drop Data Configuration Platform',
+            'semantic-mapper': {
+                title: 'Semantic Mapper for Trade Descriptions',
                 content: `
-                    <p>Built an intuitive drag-and-drop data configuration platform using Streamlit for Solidatus, enabling non-technical users to configure complex data workflows.</p>
-                    
-                    <h4>Key Features:</h4>
                     <ul>
-                        <li>Intuitive drag-and-drop interface for data mapping</li>
-                        <li>Real-time configuration validation</li>
-                        <li>Automated code generation from visual configurations</li>
-                        <li>Integration with existing Solidatus infrastructure</li>
+                        <li>Manual look-ups left trade mappings slow and error-prone.</li>
+                        <li>Combined similarity metrics with a local LLM to auto-align incoming terms and surface confidence scores.</li>
+                        <li>Embedded the zero-code tool in workflows, shrinking a four-week task to two days with higher accuracy.</li>
                     </ul>
-                    
-                    <h4>Impact:</h4>
-                    <p>Reduced configuration time by 70% and enabled business users to create data workflows independently.</p>
                 `
             },
-            'llm-pipeline': {
-                title: 'LLM-Driven Pipeline for Business Rules Conversion',
+            'adaptive-browser-agent': {
+                title: 'Adaptive Browser Automation POC',
                 content: `
-                    <p>Designed and implemented an advanced pipeline that converts complex business rules into executable code snippets using Large Language Models.</p>
-                    
-                    <h4>Technical Implementation:</h4>
                     <ul>
-                        <li>Natural language processing of business requirements</li>
-                        <li>Rule parsing and semantic analysis</li>
-                        <li>Code generation with multiple language support</li>
-                        <li>Automated testing and validation framework</li>
+                        <li>Mapped pain points of fragile RPA scripts across insurer sites.</li>
+                        <li>Created a multimodal agent that translates plain-English commands into clicks, keystrokes and waits.</li>
+                        <li>Demoed an end-to-end quote flow, sparking a rethink of future automation tooling.</li>
                     </ul>
-                    
-                    <h4>Results:</h4>
-                    <p>Achieved 85% accuracy in code generation and reduced development time for business logic implementation by 60%.</p>
                 `
             },
-            'claude-reports': {
-                title: 'Claude-Based Connection Reports for Legacy Systems',
+            'mentorship-leadership': {
+                title: 'Mentorship &amp; Scalable Solution Leadership',
                 content: `
-                    <p>Developed an intelligent reporting system using Claude AI to generate comprehensive connection reports for legacy system integration.</p>
-                    
-                    <h4>System Capabilities:</h4>
                     <ul>
-                        <li>Automated analysis of legacy system architectures</li>
-                        <li>Intelligent connection mapping and documentation</li>
-                        <li>Risk assessment and compliance reporting</li>
-                        <li>Integration recommendation engine</li>
+                        <li>Guided junior and mid-level members through complex tasks and regular check-ins.</li>
+                        <li>Maintained a central repository of reusable patterns with clear documentation.</li>
+                        <li>Onboarded new joiners quickly so they could contribute confidently to live projects.</li>
                     </ul>
-                    
-                    <h4>Business Value:</h4>
-                    <p>Reduced manual documentation effort by 90% and improved system integration planning accuracy.</p>
                 `
             },
-            'llm-scraper': {
-                title: 'Containerized LLM Scraper for Insurer Data',
+            'rule-to-js': {
+                title: 'Business Rule-to-JavaScript Converter',
                 content: `
-                    <p>Built a high-performance, containerized data extraction solution specifically designed for insurance industry data processing.</p>
-                    
-                    <h4>Architecture:</h4>
                     <ul>
-                        <li>Docker containerization for scalable deployment</li>
-                        <li>LLM-powered intelligent data extraction</li>
-                        <li>Real-time processing capabilities</li>
-                        <li>Fault-tolerant error handling and recovery</li>
+                        <li>Insurer portals needed extensive JavaScript to model calculations and validation logic.</li>
+                        <li>Developed a Python tool with a local LLM to generate validated JavaScript and automated tests from structured rules.</li>
+                        <li>Cut implementation from two weeks to two days while keeping processing on local infrastructure.</li>
                     </ul>
-                    
-                    <h4>Performance:</h4>
-                    <p>Achieved 90% faster data extraction compared to traditional methods, processing thousands of insurance documents daily.</p>
                 `
             },
-            'trade-mapping': {
-                title: 'Automated Trade-Term Mapping Solution',
+            'insurer-automation': {
+                title: 'Insurer Site Automation and Logic Engineering',
                 content: `
-                    <p>Implemented an intelligent mapping solution using GPT APIs to automate the complex process of trade term standardization and mapping.</p>
-                    
-                    <h4>Solution Components:</h4>
                     <ul>
-                        <li>GPT API integration for semantic understanding</li>
-                        <li>Trade terminology database and matching algorithms</li>
-                        <li>Confidence scoring and manual review workflows</li>
-                        <li>Continuous learning and model improvement</li>
+                        <li>Mapped dynamic question sets in Airtable to product parameters executed via Selenium.</li>
+                        <li>Crafted JavaScript validations, conditional behaviour and calculated fields.</li>
+                        <li>Built Selenium-based tests for consistent behaviour across insurer portals.</li>
                     </ul>
-                    
-                    <h4>Efficiency Gains:</h4>
-                    <p>Reduced task completion time by 90%, enabling faster trade processing and improved accuracy in financial operations.</p>
                 `
             },
-            'browser-automation': {
-                title: 'Multimodal AI Browser Automation',
+            'fraxses-layer': {
+                title: 'Unified Data Access Layer (Beneficient)',
                 content: `
-                    <p>Developed sophisticated browser automation system for insurer portal interaction using multimodal AI capabilities.</p>
-                    
-                    <h4>Advanced Features:</h4>
                     <ul>
-                        <li>Computer vision for UI element recognition</li>
-                        <li>Natural language understanding for form filling</li>
-                        <li>Adaptive navigation based on portal changes</li>
-                        <li>Error detection and recovery mechanisms</li>
+                        <li>Implemented a Fraxses workbench for virtual access to distributed datasets.</li>
+                        <li>Designed federated models unifying disparate sources into consumable views.</li>
+                        <li>Reduced data access delays and empowered business users with governed datasets.</li>
                     </ul>
-                    
-                    <h4>Use Cases:</h4>
-                    <p>Automated policy data extraction, claim processing, and regulatory reporting across multiple insurer portals.</p>
                 `
             },
-            'langchain-parsing': {
-                title: 'LangChain Parsing for Unstructured Data Quality',
+            'solidatus-ingestion': {
+                title: 'Automated Data Integration Solutions (Solidatus)',
                 content: `
-                    <p>Implemented advanced parsing solution using LangChain framework for comprehensive data quality assessment and extraction from unstructured sources.</p>
-                    
-                    <h4>Technical Stack:</h4>
                     <ul>
-                        <li>LangChain framework for document processing</li>
-                        <li>Multi-format document support (PDF, Word, Excel)</li>
-                        <li>Quality scoring algorithms</li>
-                        <li>Automated data validation and cleansing</li>
+                        <li>Identified the lack of a structured ingestion path for flat files.</li>
+                        <li>Built configurable connectors with an easy interface to handle ingestion and transformation.</li>
+                        <li>Became the standard approach, reclaiming over 200 hours each month across projects.</li>
                     </ul>
-                    
-                    <h4>Outcomes:</h4>
-                    <p>Improved data quality assessment accuracy by 75% and reduced manual data review time significantly.</p>
+                `
+            },
+            'predictive-maintenance': {
+                title: 'Accelerated Root Cause Analysis (Mitsubishi)',
+                content: `
+                    <ul>
+                        <li>Used WPS Analytics models to detect turbine failures up to 24 hours in advance.</li>
+                        <li>Streamlined root cause identification for improved operational responsiveness.</li>
+                        <li>Gained hands-on experience with WPS ML Workbench in industrial settings.</li>
+                    </ul>
+                `
+            },
+            'regulatory-compliance': {
+                title: 'Strengthened Regulatory Compliance (BNYM)',
+                content: `
+                    <ul>
+                        <li>Developed 200+ atomic and 50+ consolidated data lineage models using Solidatus and Python.</li>
+                        <li>Delivered transparent data movement and reliable FR2052A reporting.</li>
+                        <li>Reduced compliance overhead through consistent lineage across systems.</li>
+                    </ul>
+                `
+            },
+            'markets-architecture': {
+                title: 'Transformed Global Markets Architecture (BOFA)',
+                content: `
+                    <ul>
+                        <li>Created dynamic diagrams of 400+ interconnected systems in Visio and Lucidchart.</li>
+                        <li>Automated scheduled updates to keep architecture visuals current.</li>
+                        <li>Enabled leadership to make informed decisions with a reliable visual framework.</li>
+                    </ul>
                 `
             },
             'axiom-connector': {
-                title: 'Axiom Connector Engineering',
+                title: 'Engineered the Custom Connector (Axiom)',
                 content: `
-                    <p>Engineered high-performance Axiom connector that dramatically improved reporting cycle efficiency for enterprise clients.</p>
-                    
-                    <h4>Engineering Excellence:</h4>
                     <ul>
-                        <li>Optimized data connection protocols</li>
-                        <li>Parallel processing implementation</li>
-                        <li>Advanced caching mechanisms</li>
-                        <li>Real-time monitoring and alerting</li>
+                        <li>Designed a data-transformation pipeline linking Axiom with ASG, Collibra, Solidatus and EDC.</li>
+                        <li>Automated transformation logic to move data consistently across regulatory tools.</li>
+                        <li>Halved reporting cycles while improving the quality of regulatory data.</li>
                     </ul>
-                    
-                    <h4>Business Impact:</h4>
-                    <p>Achieved 50% reduction in reporting cycles, enabling faster business decision-making and improved operational efficiency.</p>
                 `
             },
-            'ml-turbine': {
-                title: 'Machine Learning Turbine Failure Detection',
+            'regulatory-design': {
+                title: 'Enhanced Regulatory Design (LSEG)',
                 content: `
-                    <p>Developed predictive maintenance solution using machine learning to detect turbine failures 24 hours before occurrence.</p>
-                    
-                    <h4>ML Implementation:</h4>
                     <ul>
-                        <li>Time-series analysis of sensor data</li>
-                        <li>Anomaly detection algorithms</li>
-                        <li>Predictive modeling with ensemble methods</li>
-                        <li>Real-time alerting system</li>
+                        <li>Built interactive Power BI dashboards with Python-based NLP for sentiment analysis.</li>
+                        <li>Uncovered process issues via word-cloud trends and reduced manual review effort by half.</li>
+                        <li>Helped leadership prioritise improvements based on real feedback.</li>
                     </ul>
-                    
-                    <h4>Results:</h4>
-                    <p>Achieved 95% accuracy in failure prediction, preventing costly downtime and reducing maintenance costs by 40%.</p>
-                `
-            },
-            'regulatory-reporting': {
-                title: 'Regulatory Reporting Acceleration for Banks',
-                content: `
-                    <p>Accelerated regulatory reporting processes for large banking institutions by building comprehensive data lineage models.</p>
-                    
-                    <h4>Scale of Implementation:</h4>
-                    <ul>
-                        <li>Built 1000+ detailed lineage models</li>
-                        <li>Covered multiple regulatory frameworks</li>
-                        <li>Automated compliance checking</li>
-                        <li>Risk assessment and monitoring</li>
-                    </ul>
-                    
-                    <h4>Compliance Impact:</h4>
-                    <p>Improved regulatory reporting accuracy and reduced compliance risk exposure for major financial institutions.</p>
-                `
-            },
-            'powerbi-nlp': {
-                title: 'Power BI NLP Dashboards',
-                content: `
-                    <p>Developed advanced analytics dashboards combining Power BI visualization capabilities with natural language processing for survey analysis.</p>
-                    
-                    <h4>Dashboard Features:</h4>
-                    <ul>
-                        <li>Real-time sentiment analysis</li>
-                        <li>Automated theme extraction</li>
-                        <li>Interactive visualizations</li>
-                        <li>Trend analysis and forecasting</li>
-                    </ul>
-                    
-                    <h4>Efficiency Improvement:</h4>
-                    <p>Reduced survey analysis effort by 50% while providing deeper insights through automated text analysis and visualization.</p>
                 `
             }
         };
-
         // Smooth scrolling for navigation
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {


### PR DESCRIPTION
## Summary
- convert hero section to two-column layout with name on the left
- place role, tagline and about text in a vertically centered right column
- make project cards tall portrait blocks and adjust responsive styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685dd45cf6dc8324996c109872702e11