### PR TITLE
Remove duplicate projects from HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -546,34 +546,10 @@
                         <p>GCP, Vertex AI and Python solutions for automated data processing and workflow management.</p>
                     </div>
 
-                    <div class="project-tile" data-project="streamlit-platform">
-                        <img src="images/15.jpg" alt="Data Configuration Platform">
-                        <h3>Data Configuration Platform</h3>
-                        <p>Drag-and-drop data configuration platform using Streamlit for Solidatus.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="llm-pipeline">
-                        <img src="images/16.jpg" alt="LLM-Driven Code Generation">
-                        <h3>LLM-Driven Code Generation</h3>
-                        <p>Pipeline converting complex business rules to code snippets using advanced language models.</p>
-                    </div>
-
                     <div class="project-tile" data-project="claude-reports">
                         <img src="images/17.jpg" alt="Claude-Based Report Generation">
                         <h3>Claude-Based Report Generation</h3>
                         <p>Automated connection reports for Legacy Systems using Claude AI technology.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="llm-scraper">
-                        <img src="images/18.jpg" alt="Containerized LLM Scraper">
-                        <h3>Containerized LLM Scraper</h3>
-                        <p>High-performance data extraction solution achieving 90% faster processing times.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="trade-mapping">
-                        <img src="images/19.jpg" alt="Trade-Term Mapping Solution">
-                        <h3>Trade-Term Mapping Solution</h3>
-                        <p>GPT API-powered automation reducing task completion time by 90%.</p>
                     </div>
 
                 </div>


### PR DESCRIPTION
## Summary
- remove duplicate project tiles for LLM-driven code generation, trade-term mapping, containerized LLM scraper and Streamlit platform

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_685df39964248324bd733915b939cb41