### PR TITLE
Adjust hero layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
         }
 
         .hero-right {
-            flex: 2;
+            flex: 1;
             display: flex;
             flex-direction: column;
             justify-content: center;


### PR DESCRIPTION
## Summary
- resize the hero-right column so the about text occupies the right half of the screen

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_685df7da52008324913ca528bed6194f