### PR TITLE
Group projects and update modal colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,33 @@
             margin-bottom: 2rem;
         }
 
+        .group-container {
+            display: flex;
+            gap: 2rem;
+            align-items: flex-start;
+        }
+
+        .group-projects {
+            flex: 3;
+        }
+
+        .group-skills {
+            flex: 1;
+        }
+
+        .group-skills .projects-grid {
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        }
+
+        .skill-tile {
+            background: white;
+            padding: 1rem;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+            text-align: center;
+            font-size: 0.9rem;
+        }
+
         .project-tile {
             display: flex;
             flex-direction: column;
@@ -269,7 +296,8 @@
         }
 
         .modal-content {
-            background: white;
+            background: #2c2c2c;
+            color: #f5f5f3;
             border-radius: 16px;
             padding: 3rem;
             max-width: 800px;
@@ -299,22 +327,22 @@
             border: none;
             font-size: 1.5rem;
             cursor: pointer;
-            color: #666;
+            color: #f5f5f3;
             transition: color 0.3s ease;
         }
 
         .close-btn:hover {
-            color: #2c2c2c;
+            color: #fff;
         }
 
         .modal-content h3 {
             font-size: 1.8rem;
             margin-bottom: 1.5rem;
-            color: #2c2c2c;
+            color: #f5f5f3;
         }
 
         .modal-content .project-details {
-            color: #555;
+            color: #ddd;
             line-height: 1.7;
             font-size: 1rem;
         }
@@ -500,137 +528,203 @@
                 </div>
             </section>
 
-            <section id="projects" class="section">
-                <h2 class="section-title">Projects</h2>
-                <div class="projects-grid">
-                    <div class="project-tile" data-project="pro-scraper">
-                        <img src="images/1.jpg" alt="Pro Scraper – Data Extraction from Insurer Sites">
-                        <h3>Pro Scraper – Data Extraction from Insurer Sites</h3>
-                        <p>LLM-powered console tool converting insurer HTML to structured JSON, cutting extraction time from weeks to days.</p>
-                    </div>
 
-                    <div class="project-tile" data-project="semantic-mapper">
-                        <img src="images/2.jpg" alt="Semantic Mapper for Trade Descriptions Mapping">
-                        <h3>Semantic Mapper – Trade Descriptions Mapping</h3>
-                        <p>Local LLM solution aligning trade descriptions with a master list for quick, accurate mappings.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="adaptive-browser-agent">
-                        <img src="images/3.jpg" alt="Adaptive Browser Automation POC">
-
-                        <h3>Adaptive Browser Automation</h3>
-                        <p>Multimodal agent translating plain-English commands into actions for flexible portal automation.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="mentorship-leadership">
-
-                        <img src="images/4.jpg" alt="Mentorship and Scalable Solution Leadership">
-                        <h3>Mentorship and Scalable Solution Leadership</h3>
-                        <p>Guided teams through reusable workflows and documentation, enabling rapid onboarding and delivery.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="rule-to-js">
-                        <img src="images/5.jpg" alt="Business Rule-to-JavaScript Converter">
-                        <h3>Business Rule-to-JavaScript Converter</h3>
-                        <p>Python tool generating validated JavaScript and tests from structured business rules.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="insurer-automation">
-                        <img src="images/6.jpg" alt="Insurer Site Automation and Logic Engineering">
-                        <h3>Insurer Site Automation and Logic Engineering</h3>
-                        <p>Selenium-driven flows mapping question sets to product parameters with reliable validation logic.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="fraxses-layer">
-                        <img src="images/7.jpg" alt="Unified Data Access Layer (Beneficient)">
-                        <h3>Unified Data Access Layer</h3>
-                        <p>Federated Fraxses models giving governed, virtual access to distributed datasets.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="solidatus-ingestion">
-                        <img src="images/8.jpg" alt="Automated Data Integration Solutions (Solidatus)">
-                        <h3>Automated Data Integration Solutions (Solidatus)</h3>
-                        <p>Configurable connectors standardising file ingestion into Solidatus, reclaiming 200+ hours monthly.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="predictive-maintenance">
-                        <img src="images/9.jpg" alt="Accelerated Root Cause Analysis (Mitsubishi)">
-                        <h3>Accelerated Root Cause Analysis</h3>
-                        <p>WPS Analytics models forecasting turbine failures 24 hours early to speed root cause analysis.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="regulatory-compliance">
-                        <img src="images/10.jpg" alt="Strengthened Regulatory Compliance (BNYM)">
-                        <h3>Strengthened Regulatory Compliance</h3>
-                        <p>Developed 250+ data lineage models for transparent, reliable reporting at BNYM.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="markets-architecture">
-                        <img src="images/11.jpg" alt="Transformed Global Markets Architecture (BOFA)">
-                        <h3>Transformed Global Markets Architecture</h3>
-                        <p>Automated diagrams of 400+ systems with scheduled updates for informed decision making.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="axiom-connector">
-                        <img src="images/12.jpg" alt="Engineered the Custom Connector (Axiom)">
-                        <h3>Engineered the Custom Connector</h3>
-                        <p>Reusable pipeline integrating Axiom with regulatory tools, halving reporting cycles.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="regulatory-design">
-                        <img src="images/13.jpg" alt="Enhanced Regulatory Design (LSEG)">
-                        <h3>Enhanced Regulatory Design </h3>
-                        <p>Power BI and NLP analysis revealing sentiment trends and reducing survey effort by 50%.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="gcp-workflows">
-                        <img src="images/14.jpg" alt="Automated Data Workflows">
-                        <h3>Automated Data Workflows</h3>
-                        <p>GCP, Vertex AI and Python solutions for automated data processing and workflow management.</p>
-                    </div>
-
-                    <div class="project-tile" data-project="claude-reports">
-                        <img src="images/17.jpg" alt="Claude-Based Report Generation">
-                        <h3>Claude-Based Report Generation</h3>
-                        <p>Automated connection reports for Legacy Systems using Claude AI technology.</p>
-                    </div>
-
+<section id="projects" class="section group-section">
+    <h2 class="section-title">AI and Automation</h2>
+    <div class="group-container">
+        <div class="group-projects">
+            <div class="projects-grid">
+                <div class="project-tile" data-project="pro-scraper">
+                    <img src="images/1.jpg" alt="Pro Scraper – Data Extraction from Insurer Sites">
+                    <h3>Pro Scraper – Data Extraction from Insurer Sites</h3>
+                    <p>LLM-powered console tool converting insurer HTML to structured JSON, cutting extraction time from weeks to days.</p>
                 </div>
-            </section>
 
-            <section id="skills" class="section">
-                <h2 class="section-title">Skills</h2>
-                <div class="skills-grid">
-                    <div class="skill-category">
-                        <h3>Cloud & Data</h3>
-                        <ul>
-                            <li>Google Cloud Platform</li>
-                            <li>Vertex AI</li>
-                            <li>Data Pipelines</li>
-                            <li>ETL/ELT</li>
-                        </ul>
-                    </div>
-                    <div class="skill-category">
-                        <h3>AI & ML</h3>
-                        <ul>
-                            <li>Large Language Models</li>
-                            <li>LangChain</li>
-                            <li>GPT API</li>
-                            <li>Claude AI</li>
-                        </ul>
-                    </div>
-                    <div class="skill-category">
-                        <h3>Programming</h3>
-                        <ul>
-                            <li>Python</li>
-                            <li>Streamlit</li>
-                            <li>Power BI</li>
-                            <li>NLP</li>
-                        </ul>
-                    </div>
+                <div class="project-tile" data-project="semantic-mapper">
+                    <img src="images/2.jpg" alt="Semantic Mapper for Trade Descriptions Mapping">
+                    <h3>Semantic Mapper – Trade Descriptions Mapping</h3>
+                    <p>Local LLM solution aligning trade descriptions with a master list for quick, accurate mappings.</p>
                 </div>
-            </section>
 
+                <div class="project-tile" data-project="adaptive-browser-agent">
+                    <img src="images/3.jpg" alt="Adaptive Browser Automation POC">
+                    <h3>Adaptive Browser Automation</h3>
+                    <p>Multimodal agent translating plain-English commands into actions for flexible portal automation.</p>
+                </div>
+
+                <div class="project-tile" data-project="rule-to-js">
+                    <img src="images/5.jpg" alt="Business Rule-to-JavaScript Converter">
+                    <h3>Business Rule-to-JavaScript Converter</h3>
+                    <p>Python tool generating validated JavaScript and tests from structured business rules.</p>
+                </div>
+
+                <div class="project-tile" data-project="gcp-workflows">
+                    <img src="images/14.jpg" alt="Automated Data Workflows">
+                    <h3>Automated Data Workflows</h3>
+                    <p>GCP, Vertex AI and Python solutions for automated data processing and workflow management.</p>
+                </div>
+
+                <div class="project-tile" data-project="claude-reports">
+                    <img src="images/17.jpg" alt="Claude-Based Report Generation">
+                    <h3>Claude-Based Report Generation</h3>
+                    <p>Automated connection reports for Legacy Systems using Claude AI technology.</p>
+                </div>
+
+                <div class="project-tile" data-project="instant-graph">
+                    <img src="images/18.jpg" alt="Instant Data-to-Graph UI">
+                    <h3>Instant Data-to-Graph UI</h3>
+                    <p>Drop a data file and instantly view interactive graphs in a Streamlit interface.</p>
+                </div>
+
+                <div class="project-tile" data-project="predictive-maintenance">
+                    <img src="images/9.jpg" alt="Accelerated Root Cause Analysis (Mitsubishi)">
+                    <h3>Accelerated Root Cause Analysis</h3>
+                    <p>WPS Analytics models forecasting turbine failures 24 hours early to speed root cause analysis.</p>
+                </div>
+            </div>
+        </div>
+        <div class="group-skills">
+            <div class="projects-grid">
+                <div class="skill-tile">Vertex AI</div>
+                <div class="skill-tile">Gen AI</div>
+                <div class="skill-tile">LangChain</div>
+                <div class="skill-tile">LangGraph</div>
+                <div class="skill-tile">CrewAI</div>
+                <div class="skill-tile">n8n</div>
+                <div class="skill-tile">Zapier</div>
+                <div class="skill-tile">LLM</div>
+                <div class="skill-tile">AI Agents</div>
+                <div class="skill-tile">Python</div>
+                <div class="skill-tile">SQL</div>
+                <div class="skill-tile">BigQuery</div>
+                <div class="skill-tile">Streamlit</div>
+                <div class="skill-tile">Browser Automation</div>
+                <div class="skill-tile">End-to-End Process Automation</div>
+                <div class="skill-tile">Rapid Prototyping &amp; Iterative Delivery</div>
+                <div class="skill-tile">Data Structures</div>
+                <div class="skill-tile">Problem Solving</div>
+                <div class="skill-tile">Research and Experimentation</div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="skills" class="section group-section">
+    <h2 class="section-title">Data Transformation and Regulatory Solutions</h2>
+    <div class="group-container">
+        <div class="group-projects">
+            <div class="projects-grid">
+                <div class="project-tile" data-project="solidatus-ingestion">
+                    <img src="images/8.jpg" alt="Automated Data Integration Solutions (Solidatus)">
+                    <h3>Automated Data Integration Solutions (Solidatus)</h3>
+                    <p>Configurable connectors standardising file ingestion into Solidatus, reclaiming 200+ hours monthly.</p>
+                </div>
+
+                <div class="project-tile" data-project="regulatory-compliance">
+                    <img src="images/10.jpg" alt="Strengthened Regulatory Compliance (BNYM)">
+                    <h3>Strengthened Regulatory Compliance</h3>
+                    <p>Developed 250+ data lineage models for transparent, reliable reporting at BNYM.</p>
+                </div>
+
+                <div class="project-tile" data-project="markets-architecture">
+                    <img src="images/11.jpg" alt="Transformed Global Markets Architecture (BOFA)">
+                    <h3>Transformed Global Markets Architecture</h3>
+                    <p>Automated diagrams of 400+ systems with scheduled updates for informed decision making.</p>
+                </div>
+
+                <div class="project-tile" data-project="axiom-connector">
+                    <img src="images/12.jpg" alt="Engineered the Custom Connector (Axiom)">
+                    <h3>Engineered the Custom Connector</h3>
+                    <p>Reusable pipeline integrating Axiom with regulatory tools, halving reporting cycles.</p>
+                </div>
+
+                <div class="project-tile" data-project="regulatory-design">
+                    <img src="images/13.jpg" alt="Enhanced Regulatory Design (LSEG)">
+                    <h3>Enhanced Regulatory Design </h3>
+                    <p>Power BI and NLP analysis revealing sentiment trends and reducing survey effort by 50%.</p>
+                </div>
+
+                <div class="project-tile" data-project="fraxses-layer">
+                    <img src="images/7.jpg" alt="Unified Data Access Layer (Beneficient)">
+                    <h3>Unified Data Access Layer</h3>
+                    <p>Federated Fraxses models giving governed, virtual access to distributed datasets.</p>
+                </div>
+
+                <div class="project-tile" data-project="insurer-automation">
+                    <img src="images/6.jpg" alt="Insurer Site Automation and Logic Engineering">
+                    <h3>Insurer Site Automation and Logic Engineering</h3>
+                    <p>Selenium-driven flows mapping question sets to product parameters with reliable validation logic.</p>
+                </div>
+            </div>
+        </div>
+        <div class="group-skills">
+            <div class="projects-grid">
+                <div class="skill-tile">Fraxses</div>
+                <div class="skill-tile">Solidatus</div>
+                <div class="skill-tile">Google Cloud Platform (GCP)</div>
+                <div class="skill-tile">WPS Analytics</div>
+                <div class="skill-tile">Docker</div>
+                <div class="skill-tile">PostgreSQL</div>
+                <div class="skill-tile">Microsoft Power BI</div>
+                <div class="skill-tile">Lucidchart</div>
+                <div class="skill-tile">Visio</div>
+                <div class="skill-tile">SmartDraw</div>
+                <div class="skill-tile">Microsoft Excel</div>
+                <div class="skill-tile">Microsoft Access DB</div>
+                <div class="skill-tile">Data Lineage</div>
+                <div class="skill-tile">Data Visualization</div>
+                <div class="skill-tile">Data Analytics</div>
+                <div class="skill-tile">Cross-System Data Integration</div>
+                <div class="skill-tile">End-to-End Solution Design</div>
+                <div class="skill-tile">Scalable System Development</div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="mentorship" class="section group-section">
+    <h2 class="section-title">Mentorship, Process Enablement, and Client Interaction</h2>
+    <div class="group-container">
+        <div class="group-projects">
+            <div class="projects-grid">
+                <div class="project-tile" data-project="mentorship-leadership">
+                    <img src="images/4.jpg" alt="Mentorship and Scalable Solution Leadership">
+                    <h3>Mentorship and Scalable Solution Leadership</h3>
+                    <p>Guided teams through reusable workflows and documentation, enabling rapid onboarding and delivery.</p>
+                </div>
+
+                <div class="project-tile" data-project="process-docs">
+                    <img src="images/15.jpg" alt="Process Documentation and Knowledge Sharing">
+                    <h3>Process Documentation and Knowledge Sharing</h3>
+                    <p>Established a central knowledge base and standard operating procedures for all major workflows.</p>
+                </div>
+
+                <div class="project-tile" data-project="hands-on-training">
+                    <img src="images/16.jpg" alt="Hands-on Technical Training and Enablement">
+                    <h3>Hands-on Technical Training and Enablement</h3>
+                    <p>Delivered workshops and pair programming sessions to accelerate team adoption of new tools.</p>
+                </div>
+
+                <div class="project-tile" data-project="client-collaboration">
+                    <img src="images/19.jpg" alt="Stakeholder &amp; Client Collaboration">
+                    <h3>Stakeholder &amp; Client Collaboration</h3>
+                    <p>Worked closely with clients and stakeholders to align technical solutions with business goals.</p>
+                </div>
+            </div>
+        </div>
+        <div class="group-skills">
+            <div class="projects-grid">
+                <div class="skill-tile">Mentoring &amp; Leadership</div>
+                <div class="skill-tile">Cross-Functional Team Leadership</div>
+                <div class="skill-tile">Vendor Evaluation &amp; Cost Estimation</div>
+                <div class="skill-tile">Stakeholder Communication &amp; Alignment</div>
+                <div class="skill-tile">Agile Delivery (Scrum, Kanban)</div>
+                <div class="skill-tile">Team Collaboration</div>
+                <div class="skill-tile">End-to-End Solution Design</div>
+            </div>
+        </div>
+    </div>
+</section>
             <section id="links" class="section">
                 <h2 class="section-title">Interesting Space</h2>
                 <div class="contact-content">
@@ -823,6 +917,46 @@
                       <li>Built a Claude-based multi-step solution to extract and link unstructured elements, generating structured relationship tables.</li>
                       <li>Cut manual effort and inconsistency by accelerating cross-component mapping and improving system integration.</li>
                    </ul> `
+            },
+
+            'instant-graph': {
+                title: 'Instant Data-to-Graph UI',
+                content: `
+                    <ul>
+                        <li>Streamlit interface turning CSV data into interactive graphs instantly.</li>
+                        <li>Allowed quick exploration of datasets with zero coding.</li>
+                        <li>Enabled business teams to visualise information on demand.</li>
+                    </ul> `
+            },
+
+            'process-docs': {
+                title: 'Process Documentation and Knowledge Sharing',
+                content: `
+                    <ul>
+                        <li>Created centralised SOPs for all major workflows.</li>
+                        <li>Maintained a knowledge base to speed onboarding.</li>
+                        <li>Improved alignment across project teams.</li>
+                    </ul> `
+            },
+
+            'hands-on-training': {
+                title: 'Hands-on Technical Training and Enablement',
+                content: `
+                    <ul>
+                        <li>Led workshops and pair programming sessions on automation tools.</li>
+                        <li>Provided real project examples to reinforce learning.</li>
+                        <li>Accelerated adoption of new technologies.</li>
+                    </ul> `
+            },
+
+            'client-collaboration': {
+                title: 'Stakeholder & Client Collaboration',
+                content: `
+                    <ul>
+                        <li>Regular sync-ups ensured technical solutions matched business goals.</li>
+                        <li>Translated complex concepts into clear outcomes for stakeholders.</li>
+                        <li>Built lasting relationships through transparent communication.</li>
+                    </ul> `
             }
 
             


### PR DESCRIPTION
## Summary
- reorganize portfolio projects into three groups
- add per-group skill tiles using existing grid style
- implement 75/25 layout with new CSS classes
- restyle the project modal with a dark theme
- provide details for new projects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68646f4831508324918a1a95ceb37750