### PR TITLE
Adjust projects grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,19 +195,16 @@
         /* Projects Grid */
         .projects-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-            grid-auto-rows: 160px;
-            grid-auto-flow: dense;
+            grid-template-columns: repeat(3, 1fr);
             gap: 0;
             margin-bottom: 2rem;
-            border-left: 1px solid #fff;
-            border-top: 1px solid #fff;
+            border: 1px solid #fff;
         }
 
         .group-container {
             display: flex;
             gap: 2rem;
-            align-items: flex-start;
+            align-items: stretch;
         }
 
         .group-projects {
@@ -216,21 +213,23 @@
 
         .group-skills {
             flex: 1;
+            display: flex;
+            flex-direction: column;
         }
 
         .group-skills .projects-grid {
             grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-            grid-auto-rows: 120px;
-            grid-auto-flow: dense;
+            height: 100%;
             gap: 0;
-            border-left: 1px solid #fff;
-            border-top: 1px solid #fff;
+            border: 1px solid #fff;
+            flex: 1;
         }
 
         .skill-tile {
             display: flex;
             align-items: center;
             justify-content: center;
+            aspect-ratio: 1 / 1;
             padding: 1rem;
             font-size: 0.9rem;
             color: #fff;
@@ -245,7 +244,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            min-height: 120px;
+            aspect-ratio: 1 / 1;
             padding: 1rem;
             color: #fff;
             cursor: pointer;
@@ -254,6 +253,7 @@
             text-align: center;
             background: rgba(0, 0, 0, 0.6);
             transition: background 0.3s ease;
+            font-size: 1rem;
         }
 
         .project-tile:hover,
@@ -261,21 +261,6 @@
             background: linear-gradient(135deg, rgba(255,255,255,0.15), rgba(255,255,255,0));
         }
 
-        .projects-grid .project-tile:nth-child(5n) {
-            grid-row: span 2;
-        }
-
-        .projects-grid .project-tile:nth-child(7n) {
-            grid-column: span 2;
-        }
-
-        .projects-grid .skill-tile:nth-child(3n) {
-            grid-column: span 2;
-        }
-
-        .projects-grid .skill-tile:nth-child(4n) {
-            grid-row: span 2;
-        }
 
         .skills-title {
             font-size: 1.2rem;


### PR DESCRIPTION
## Summary
- make project tiles uniform squares
- remove variable tile sizing
- stretch skills section and grid
- wrap grids with consistent borders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864809b34f08324a0889dc4221854b7