### PR TITLE
Update color scheme and text contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,10 +27,10 @@
             position: fixed;
             top: 0;
             width: 100%;
-            background: #000;
+            background: #F2F2F2;
             padding: 1rem 2rem;
             z-index: 1000;
-            border-bottom: 1px solid #fff;
+            border-bottom: 1px solid #000;
         }
 
         .nav-container {
@@ -46,7 +46,7 @@
         .logo {
             font-size: 1.4rem;
             font-weight: 700;
-            color: #fff;
+            color: #000;
             text-decoration: none;
             letter-spacing: 0.5px;
         }
@@ -59,7 +59,7 @@
 
         .nav-links a {
             text-decoration: none;
-            color: #fff;
+            color: #000;
             font-weight: 400;
             font-size: 0.9rem;
             transition: all 0.3s ease;
@@ -67,7 +67,7 @@
         }
 
         .nav-links a:hover {
-            color: #ccc;
+            color: #333;
         }
 
         .nav-links a::after {
@@ -77,7 +77,7 @@
             left: 0;
             width: 0;
             height: 1px;
-            background-color: #fff;
+            background-color: #000;
             transition: width 0.3s ease;
         }
 
@@ -228,6 +228,7 @@
             grid-template-columns: repeat(4, 1fr);
             gap: 1rem;
             min-height: 200px;
+            background: #393E46;
         }
 
         .skill-label {
@@ -243,10 +244,10 @@
             justify-content: flex-start;
             aspect-ratio: 1 / 1;
             padding: 1rem;
-            color: #000;
+            color: #fff;
             cursor: pointer;
             text-align: center;
-            background: #fff;
+            background: #222831;
             transition: background 0.3s ease;
             font-size: 1rem;
             border-radius: 12px;
@@ -280,7 +281,7 @@
             font-size: 1.1rem;
             font-weight: 300;
             margin: auto 0;
-            color: #000;
+            color: #fff;
             font-family: 'Helvetica Neue', Arial, sans-serif;
         }
 


### PR DESCRIPTION
## Summary
- update navigation bar background to light grey with black text
- adjust project tile background to dark grey with white text
- set skills block background to darker grey

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6865dceda20c8324a1e76e38317b2689