### PR TITLE
Apply light color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 
         body {
             font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            background-color: #000;
-            color: #fff;
+            background-color: #F2F2F2;
+            color: #000;
             line-height: 1.6;
             background-image:
                 linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px),
@@ -35,7 +35,7 @@
             background: #F2F2F2;
             padding: 1rem 2rem;
             z-index: 1000;
-            border-bottom: 1px solid #000;
+            border-bottom: 1px solid #B6B09F;
         }
 
         .nav-container {
@@ -72,7 +72,7 @@
         }
 
         .nav-links a:hover {
-            color: #333;
+            color: #B6B09F;
         }
 
         .nav-links a::after {
@@ -82,7 +82,7 @@
             left: 0;
             width: 0;
             height: 1px;
-            background-color: #000;
+            background-color: #B6B09F;
             transition: width 0.3s ease;
         }
 
@@ -137,7 +137,7 @@
         .hero-name {
             font-size: 3rem;
             font-weight: 300;
-            color: #fff;
+            color: #000;
         }
 
         .hero-right {
@@ -151,12 +151,12 @@
             font-size: 2.2rem;
             font-weight: 300;
             margin-bottom: 1rem;
-            color: #fff;
+            color: #000;
         }
 
         .hero .subtitle {
             font-size: 1.2rem;
-            color: #ccc;
+            color: #333;
             margin-bottom: 2rem;
             max-width: 600px;
         }
@@ -179,7 +179,7 @@
             font-weight: 300;
             margin-bottom: 3rem;
             text-align: center;
-            color: #fff;
+            color: #000;
         }
 
         .about-title {
@@ -194,7 +194,7 @@
             text-align: left;
             font-size: 1.1rem;
             line-height: 1.8;
-            color: #ccc;
+            color: #333;
         }
 
         /* Projects Grid */
@@ -227,18 +227,18 @@
         }
 
         .skills-block {
-            border: 1px solid #fff;
+            border: 1px solid #B6B09F;
             padding: 1.5rem;
             display: grid;
             grid-template-columns: repeat(4, 1fr);
             gap: 1rem;
             min-height: 200px;
-            background: #393E46;
+            background: #EAE4D5;
         }
 
         .skill-label {
             font-size: 0.9rem;
-            color: #fff;
+            color: #000;
             text-align: center;
         }
 
@@ -249,10 +249,10 @@
             justify-content: flex-start;
             aspect-ratio: 1 / 1;
             padding: 1rem;
-            color: #fff;
+            color: #000;
             cursor: pointer;
             text-align: center;
-            background: #222831;
+            background: #EAE4D5;
             transition: background 0.3s ease;
             font-size: 1rem;
             border-radius: 12px;
@@ -260,7 +260,7 @@
         }
 
         .project-tile:hover {
-            background: linear-gradient(135deg, rgba(0,0,0,0.05), rgba(0,0,0,0));
+            background: linear-gradient(135deg, rgba(182,176,159,0.2), rgba(0,0,0,0));
         }
 
 
@@ -268,7 +268,7 @@
             text-align: center;
             font-size: 1.2rem;
             font-weight: 300;
-            color: #fff;
+            color: #000;
             margin: 0 0 1rem 0;
         }
 
@@ -283,10 +283,10 @@
         }
 
         .project-tile h3 {
-            font-size: 1.1rem;
+            font-size: 1.25rem;
             font-weight: 300;
             margin: auto 0;
-            color: #fff;
+            color: #000;
             font-family: 'Helvetica Neue', Arial, sans-serif;
         }
 
@@ -374,20 +374,20 @@
 
         .skill-category {
             padding: 2rem;
-            border: 1px solid #fff;
+            border: 1px solid #B6B09F;
             text-align: center;
-            color: #fff;
+            color: #000;
         }
 
         .skill-category h3 {
             font-size: 1.2rem;
             margin-bottom: 1rem;
-            color: #fff;
+            color: #000;
         }
 
         .skill-category ul {
             list-style: none;
-            color: #ccc;
+            color: #333;
         }
 
         .skill-category li {
@@ -424,10 +424,10 @@
 
         .contact-links a {
             text-decoration: none;
-            color: #fff;
+            color: #000;
             font-weight: 500;
             padding: 0.8rem 1.5rem;
-            border: 1px solid #fff;
+            border: 1px solid #B6B09F;
             border-radius: 0;
         }
 
@@ -435,7 +435,7 @@
         footer {
             text-align: center;
             padding: 3rem 2rem;
-            color: #fff;
+            color: #000;
             font-size: 0.9rem;
         }
 


### PR DESCRIPTION
## Summary
- switch to light background and text colors
- style navigation and accent borders with new palette
- update project tiles and skills blocks to lighter scheme
- enlarge project tile titles for readability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68728ec5e03c832483b8d47c69b3c356