### PR TITLE
Reorder and rename AI projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -574,64 +574,69 @@
     <div class="group-container">
         <div class="group-projects">
             <div class="projects-grid">
+                <div class="project-tile" data-project="instant-graph">
+                    <h3>Agentic Data-to-Graph UI – Real-Time Postgres-to-Lineage Mapping</h3>
+                    <img src="images/7.jpg" alt="Agentic Data-to-Graph UI">
+                </div>
+
                 <div class="project-tile" data-project="pro-scraper">
-                    <h3>Pro Scraper – Data Extraction from Insurer Sites</h3>
-                    <img src="images/1.jpg" alt="Pro Scraper">
+                    <h3>Agentic Pro Scraper – Automated Insurer Portal Data Extraction</h3>
+                    <img src="images/1.jpg" alt="Agentic Pro Scraper">
                 </div>
 
                 <div class="project-tile" data-project="semantic-mapper">
-                    <h3>Semantic Mapper – Trade Descriptions Mapping</h3>
-                    <img src="images/2.jpg" alt="Semantic Mapper">
-                </div>
-
-                <div class="project-tile" data-project="adaptive-browser-agent">
-                    <h3>Adaptive Browser Automation</h3>
-                    <img src="images/3.jpg" alt="Adaptive Browser Automation">
+                    <h3>Agentic Semantic Mapper – High-Precision Trade Term Matching</h3>
+                    <img src="images/2.jpg" alt="Agentic Semantic Mapper">
                 </div>
 
                 <div class="project-tile" data-project="rule-to-js">
-                    <h3>Business Rule-to-JavaScript Converter</h3>
-                    <img src="images/4.jpg" alt="Business Rule Converter">
+                    <h3>Intelligent Business Rule Automation – Code &amp; Testcase Orchestration</h3>
+                    <img src="images/4.jpg" alt="Intelligent Business Rule Automation">
+                </div>
+
+                <div class="project-tile" data-project="python-rag-chatbot">
+                    <h3>AI-Powered RAG Chatbot – Instant Python Documentation Q&amp;A</h3>
+                    <img src="images/17.jpg" alt="AI-Powered RAG Chatbot">
+                </div>
+
+                <div class="project-tile" data-project="gemini-finetune">
+                    <h3>Autonomous Email Handling – Gemini-Optimized Support Workflows</h3>
+                    <img src="images/18.jpg" alt="Autonomous Email Handling">
+                </div>
+
+                <div class="project-tile" data-project="adaptive-browser-agent">
+                    <h3>Intelligent Browser Automation – Dynamic Web Navigation</h3>
+                    <img src="images/3.jpg" alt="Intelligent Browser Automation">
                 </div>
 
                 <div class="project-tile" data-project="gcp-workflows">
-                    <h3>Automated Data Workflows</h3>
-                    <img src="images/5.jpg" alt="Automated Data Workflows">
+                    <h3>Cloud-Orchestrated AI Data Pipelines – Vertex AI &amp; GCP</h3>
+                    <img src="images/5.jpg" alt="Cloud-Orchestrated AI Data Pipelines">
                 </div>
 
                 <div class="project-tile" data-project="claude-reports">
-                    <h3>Claude-Based Report Generation</h3>
-                    <img src="images/6.jpg" alt="Claude-Based Reports">
-                </div>
-
-                <div class="project-tile" data-project="instant-graph">
-                    <h3>Instant Data-to-Graph UI (Postgres, LLM, Solidatus)</h3>
-                    <img src="images/7.jpg" alt="Instant Graph UI">
+                    <h3>Automated Workflow for Claude-Powered Compliance Reporting</h3>
+                    <img src="images/6.jpg" alt="Claude-Powered Compliance Reporting">
                 </div>
 
                 <div class="project-tile" data-project="predictive-maintenance">
-                    <h3>Accelerated Root Cause Analysis</h3>
-                    <img src="images/8.jpg" alt="Predictive Maintenance">
+                    <h3>Gas Turbine Fault Diagnosis – 24-Hour Predictive Alert System</h3>
+                    <img src="images/8.jpg" alt="Gas Turbine Fault Diagnosis">
                 </div>
-                <div class="project-tile" data-project="vertex-automl">
-                    <h3>Predicting Term Deposit Subscriptions</h3>
-                    <img src="images/15.jpg" alt="Vertex AutoML">
-                </div>
-                <div class="project-tile" data-project="bqml-churn">
-                    <h3>Telecom Customer Churn Prediction</h3>
-                    <img src="images/16.jpg" alt="BigQuery ML Churn">
-                </div>
-                <div class="project-tile" data-project="python-rag-chatbot">
-                    <h3>Python Docs Chatbot with RAG</h3>
-                    <img src="images/17.jpg" alt="Python RAG Chatbot">
-                </div>
-                <div class="project-tile" data-project="gemini-finetune">
-                    <h3>Fine-Tuning Gemini for Support Emails</h3>
-                    <img src="images/18.jpg" alt="Gemini Email">
-                </div>
+
                 <div class="project-tile" data-project="invoice-agents">
-                    <h3>Multi-Agent Invoice Generation</h3>
-                    <img src="images/19.jpg" alt="Invoice Agents">
+                    <h3>Orchestrated Invoice Generation – From Image to PDF in Minutes</h3>
+                    <img src="images/19.jpg" alt="Orchestrated Invoice Generation">
+                </div>
+
+                <div class="project-tile" data-project="bqml-churn">
+                    <h3>AI-Driven Telecom Churn Prediction – BigQuery ML at Scale</h3>
+                    <img src="images/16.jpg" alt="AI-Driven Telecom Churn Prediction">
+                </div>
+
+                <div class="project-tile" data-project="vertex-automl">
+                    <h3>Machine Learning for Term Deposit Subscriptions – Vertex AutoML</h3>
+                    <img src="images/15.jpg" alt="Term Deposit Subscription Prediction">
                 </div>
             </div>
         </div>
@@ -814,7 +819,7 @@
 
         const projectDetails = {
             'pro-scraper': {
-                title: 'Pro Scraper – Data Extraction from Insurer Sites',
+                title: 'Agentic Pro Scraper – Automated Insurer Portal Data Extraction',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Insurer portals had dynamic layouts and no export option, forcing weeks of fragile copy/paste or custom JavaScript to capture question sets. Manual steps frequently produced errors.</li>
@@ -825,18 +830,18 @@
                 `
             },
             'semantic-mapper': {
-                title: 'Semantic Mapper – Trade Descriptions Mapping',
+                title: 'Agentic Semantic Mapper – High-Precision Trade Term Matching',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Insurers listed hundreds of trades with inconsistent naming, making alignment to our master list slow and error‑prone. Confusion wasted time for analysts.</li>
                         <li><strong>Solution:</strong> Implemented a multi‑agent mapping pipeline: an exact‑match agent cleared obvious cases, a semantic agent combined classical similarity scores with LLM reasoning for the rest, and a review agent captured analyst feedback in Airtable. A training agent fine‑tuned the model each cycle and could switch between proprietary and open‑source LLMs to meet data‑privacy needs.</li>
-                        <li><strong>Business Impact:</strong> Together with Pro Scraper, the automated workflow cut trade mapping from 4 weeks to 3 days while delivering high‑precision results. Docker packaging, documentation and hands‑on training embedded the process into day‑to‑day operations.</li>
+                        <li><strong>Business Impact:</strong> Together with Agentic Pro Scraper, the automated workflow cut trade mapping from 4 weeks to 3 days while delivering high‑precision results. Docker packaging, documentation and hands‑on training embedded the process into day‑to‑day operations.</li>
                         <li><strong>Tech Stack:</strong> Python (fuzzywuzzy, Jaccard, cosine, Jaro‑Winkler), Streamlit, Airtable, Docker, OpenAI API/Local LLMs, pandas, Excel/JSON</li>
                     </ul>
                 `
             },
             'adaptive-browser-agent': {
-                title: 'Adaptive Browser Automation POC',
+                title: 'Intelligent Browser Automation – Dynamic Web Navigation',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Custom RPA scripts were required for each insurer site, resulting in long build cycles and fragile maintenance. Scripts were brittle and costly.</li>
@@ -858,7 +863,7 @@
                 `
             },
             'rule-to-js': {
-                title: 'Business Rule-to-JavaScript Converter',
+                title: 'Intelligent Business Rule Automation – Code &amp; Testcase Orchestration',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Insurer portals relied on large JavaScript codebases for calculations, flows and validations. Manual coding slowed updates significantly.</li>
@@ -902,7 +907,7 @@
                 `
             },
             'predictive-maintenance': {
-                title: 'Accelerated Root Cause Analysis (Mitsubishi)',
+                title: 'Gas Turbine Fault Diagnosis – 24-Hour Predictive Alert System',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Needed early detection of turbine failures to reduce downtime. Unexpected failures stalled production schedules.</li>
@@ -913,7 +918,7 @@
                 `
             },
             'vertex-automl': {
-                title: 'Predicting Term Deposit Subscriptions with Vertex AutoML',
+                title: 'Machine Learning for Term Deposit Subscriptions – Vertex AutoML',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Banks needed a scalable way to identify customers likely to subscribe to term deposits. Manual targeting wasted valuable marketing spend.</li>
@@ -924,7 +929,7 @@
                 `
             },
             'bqml-churn': {
-                title: 'Telecom Customer Churn Prediction with BigQuery ML',
+                title: 'AI-Driven Telecom Churn Prediction – BigQuery ML at Scale',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Telecom providers needed to predict customer churn to prioritise retention efforts. Losses from churn impacted profits heavily.</li>
@@ -935,7 +940,7 @@
                 `
             },
             'python-rag-chatbot': {
-                title: 'Python Docs Q&A Chatbot using RAG',
+                title: 'AI-Powered RAG Chatbot – Instant Python Documentation Q&A',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Static Python documentation PDFs were difficult to search interactively. Users wasted time flipping through pages.</li>
@@ -946,7 +951,7 @@
                 `
             },
             'gemini-finetune': {
-                title: 'Fine-Tuning Gemini for Customer Support Email Drafting',
+                title: 'Autonomous Email Handling – Gemini-Optimized Support Workflows',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Drafting consistent customer support emails was labour intensive. Agents spent hours drafting personalised responses.</li>
@@ -957,7 +962,7 @@
                 `
             },
             'invoice-agents': {
-                title: 'Multi-Agent Workflow for Automated Invoice Generation',
+                title: 'Orchestrated Invoice Generation – From Image to PDF in Minutes',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Generating invoices from order images required multiple manual steps. Manual entry caused delayed billing cycles.</li>
@@ -1012,7 +1017,7 @@
                 `
             },
             'gcp-workflows': {
-                title: 'Automated Data Workflows with GCP, Vertex AI and Python',
+                title: 'Cloud-Orchestrated AI Data Pipelines – Vertex AI &amp; GCP',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Document processing and data validation required manual effort and lacked scalability. Complex documents slowed validation across systems.</li>
@@ -1023,7 +1028,7 @@
             },
 
             'claude-reports': {
-                title: 'Claude-Based Report Generation for Legacy Systems',
+                title: 'Automated Workflow for Claude-Powered Compliance Reporting',
                 content: `
                    <ul>
                       <li><strong>Problem:</strong> Legacy models, methodology documents and R scripts lacked a consistent mapping of relationships, hindering automation. Documentation lacked structure for automation.</li>
@@ -1034,7 +1039,7 @@
             },
 
             'instant-graph': {
-                title: 'Instant Data-to-Graph UI (Postgres, LLM, Solidatus)',
+                title: 'Agentic Data-to-Graph UI – Real-Time Postgres-to-Lineage Mapping',
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Preparing data for ingestion into Solidatus, a graph-based data lineage tool, was previously a time-consuming, multi-step process. Clients often provided access to their data via a virtual database, requiring analysts to get their data from there. Later, converting this into the format required by Solidatus meant manually interpreting, changing and sometimes unclear requirements to build the right structure. Multiple data tables frequently needed to be stitched together through custom joins, adding further complexity. This process required constant developer involvement, lacked flexibility, and couldn't support fast experimentation, slowing down delivery. Data sources varied widely and changed frequently.</li>
@@ -1049,7 +1054,7 @@
                 content: `
                     <ul>
                         <li><strong>Problem:</strong> Lack of standard documentation made it difficult to reuse solutions and hand over projects. Tribal knowledge led to repeated mistakes.</li>
-                        <li><strong>Solution:</strong> Documented AI tools such as Pro Scraper and Semantic Mapper, and produced reusable code patterns and templates. Guides capture best practices for reuse.</li>
+                        <li><strong>Solution:</strong> Documented AI tools such as Agentic Pro Scraper and Agentic Semantic Mapper, and produced reusable code patterns and templates. Guides capture best practices for reuse.</li>
                         <li><strong>Business Impact:</strong> Standardised documentation eased future handovers and encouraged solution reuse. Consistent docs sped new team onboarding.</li>
                         <li><strong>Tech Stack:</strong> Markdown, Python, Knowledge Management Tools</li>
                     </ul> `


### PR DESCRIPTION
## Summary
- rename AI and Automation projects to new agentic titles
- reorganize project grid to match updated order and refresh related project detail titles

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f9b4ca91c8324a949543a8254809e