### PR TITLE
Update RAG project description to internal onboarding interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,9 +594,9 @@
                     <img src="images/4.jpg" alt="Intelligent Business Rule Automation">
                 </div>
 
-                <div class="project-tile" data-project="python-rag-chatbot">
-                    <h3>AI-Powered RAG Chatbot – Instant Python Documentation Q&amp;A</h3>
-                    <img src="images/17.jpg" alt="AI-Powered RAG Chatbot">
+                <div class="project-tile" data-project="rag-interface">
+                    <h3>AI-Powered RAG Interface – A self-service platform for all Q&amp;A</h3>
+                    <img src="images/17.jpg" alt="AI-Powered RAG Interface">
                 </div>
 
                 <div class="project-tile" data-project="gemini-finetune">
@@ -939,14 +939,14 @@
                     </ul>
                 `
             },
-            'python-rag-chatbot': {
-                title: 'AI-Powered RAG Chatbot – Instant Python Documentation Q&A',
+            'rag-interface': {
+                title: 'AI-Powered RAG Interface – A self-service platform for all Q&A',
                 content: `
                     <ul>
-                        <li><strong>Problem:</strong> Static Python documentation PDFs were difficult to search interactively. Users wasted time flipping through pages.</li>
-                        <li><strong>Solution:</strong> Indexed the docs with Vertex RAG Engine and Gemini, deploying a chatbot on Cloud Run. Pipeline uses embeddings for fast retrieval.</li>
-                        <li><strong>Business Impact:</strong> Turns unstructured docs into an interactive, searchable experience. Greater accessibility helps developers learn faster.</li>
-                        <li><strong>Tech Stack:</strong> Vertex RAG Engine, Gemini, GCS, Cloud Run</li>
+                        <li><strong>Problem:</strong> Internal tools lacked public documentation or community support, forcing new hires to rely on a few experts and sift through extensive policies and procedures.</li>
+                        <li><strong>Solution:</strong> Built a RAG-based platform using LangChain and LangGraph with a vector database, paired with a Streamlit UI that lets users choose a tool or domain and ask questions for instant answers.</li>
+                        <li><strong>Business Impact:</strong> Cut onboarding time by 70%, freeing mentors and accelerating new employee productivity.</li>
+                        <li><strong>Tech Stack:</strong> LangChain, LangGraph, vector database, Streamlit</li>
                     </ul>
                 `
             },


### PR DESCRIPTION
## Summary
- replace Python docs chatbot project with AI-Powered RAG Interface entry
- describe internal self-service platform using LangChain/LangGraph and Streamlit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa11f86bc83249718c3d563e0b082